### PR TITLE
updated MultiQC version, Dockerfile points to 1.14 instead of 1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-ARG MULTIQC_VERSION=v1.11
+ARG MULTIQC_VERSION=v1.14
 
 LABEL author="David Brawand" \
       description="MultiQC ${MULTIQC_VERSION} with SEGLH plugin" \


### PR DESCRIPTION
This one character change will mean a Docker image will reflect the moka guys v1.14 MultiQC dockerfile when made, while keeping the modules added in the eggd version

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/multiqc_plugins/2)
<!-- Reviewable:end -->
